### PR TITLE
Fix Parameters Issue on Windows

### DIFF
--- a/content/FLASHDeconv/FLASHDeconvWorkflow.py
+++ b/content/FLASHDeconv/FLASHDeconvWorkflow.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from src.Workflow import DeconvWorkflow
 from src.parse.deconv import parseDeconv
-from src.common.common import page_setup
+from src.common.common import page_setup, save_params
 
 
 params = page_setup()
@@ -171,3 +171,5 @@ with t[3]:
             wf.file_manager.clear_cache()
             st.success("All files removed!")
             st.rerun()
+
+save_params(params)

--- a/content/FLASHTnT/FLASHTnTWorkflow.py
+++ b/content/FLASHTnT/FLASHTnTWorkflow.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from src.parse.tnt import parseTnT
 from src.Workflow import TagWorkflow
-from src.common.common import page_setup
+from src.common.common import page_setup, save_params
 
 
 params = page_setup()
@@ -168,3 +168,5 @@ with t[3]:
             wf.file_manager.clear_cache()
             st.success("All files removed!")
             st.rerun()
+
+save_params(params)


### PR DESCRIPTION
Currently on windows file parameters cannot be found when executing a workflow for the first time. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parameters are now automatically saved at the end of each workflow, ensuring your settings are preserved after each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->