### PR TITLE
Fix TypeError when protein description is not a string

### DIFF
--- a/src/parse/tnt.py
+++ b/src/parse/tnt.py
@@ -34,7 +34,7 @@ def parseTnT(file_manager, dataset_id, deconv_mzML, anno_mzML, tag_tsv, protein_
         }
     )
     protein_df['description'] = protein_df['description'].apply(
-        lambda x: x[:50] + '...' if len(x) > 50 else x
+        lambda x: str(x)[:50] + '...' if len(str(x)) > 50 else str(x)
     )
     file_manager.store_data(dataset_id, 'protein_dfs', protein_df)
     logger.log("30.0 %", level=2)


### PR DESCRIPTION
Handle cases where protein description values may be non-string types (e.g., NaN, float) by explicitly converting to string before truncation. This prevents "TypeError: object of type 'float' has no len()" errors when parsing FLASHTnT results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of protein description handling to safely process and truncate descriptions regardless of input data type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->