### PR TITLE
Upgrade to OpenMS 3.5.0 and Qt 6

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -11,7 +11,7 @@ on:
 # Define needed TOPP tools here
 env:
   TOPP_TOOLS: "FLASHDeconv FLASHTnT DecoyDatabase"
-  OPENMS_VERSION: 3.2.0 
+  OPENMS_VERSION: 3.5.0
   PYTHON_VERSION: 3.11.0
   # Name of the installer
   APP_NAME: FLASHApp-0.9.15
@@ -61,14 +61,10 @@ jobs:
         path: 'OpenMS'
     
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
-        version: '5.15.2' # 5.12.7 is broken https://bugreports.qt.io/browse/QTBUG-81715, > 5.15.2 is not available on official archives (https://github.com/miurahr/aqtinstall/issues/636)
-        host: 'windows' # default: win64_msvc2017_64
-        target: 'desktop'
-        install-deps: 'true'
-        cache: 'false'
-        aqtversion: '==3.1.*'
+        version: '6.8.3'
+        arch: 'win64_msvc2022_64'
 
     # https://github.com/marketplace/actions/visual-studio-shell
     - name: Set up Visual Studio shell
@@ -137,7 +133,7 @@ jobs:
           # add third-party binaries to PATH
           # use flat THIRDPARTY structure
           mkdir -p _thirdparty
-          cp -R OpenMS/THIRDPARTY/Windows/64bit/* _thirdparty/
+          cp -R OpenMS/THIRDPARTY/Windows/x86_64/* _thirdparty/
           cp -R OpenMS/THIRDPARTY/All/* _thirdparty/
           # add third-party binaries to PATH
           for thirdpartytool in ${{ github.workspace }}/_thirdparty/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-da
                                                                      libboost-regex1.74-dev \
                                                                      libboost-math1.74-dev \
                                                                      libboost-random1.74-dev
-RUN apt-get install -y --no-install-recommends --no-install-suggests qtbase5-dev libqt5svg5-dev libqt5opengl5-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests qt6-base-dev libqt6svg6-dev libqt6opengl6-dev libqt6openglwidgets6 libgl-dev
 
 # Install Github CLI
 RUN (type -p wget >/dev/null || (apt-get update && apt-get install wget -y)) \
@@ -80,7 +80,7 @@ SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
 
 # Install up-to-date cmake via mamba and packages for pyOpenMS build.
 RUN mamba install cmake
-RUN pip install --upgrade pip && python -m pip install -U setuptools nose 'Cython<3.1' 'autowrap<0.23' pandas 'numpy==1.26.4' pytest
+RUN pip install --upgrade pip && python -m pip install -U setuptools nose cython "autowrap<=0.24" pandas numpy pytest
 
 # Clone OpenMS branch and the associcated contrib+thirdparties+pyOpenMS-doc submodules.
 RUN git clone --recursive --depth=1 -b ${OPENMS_BRANCH} --single-branch ${OPENMS_REPO} && cd /OpenMS
@@ -90,7 +90,7 @@ WORKDIR /OpenMS
 RUN mkdir /thirdparty && \
     git submodule update --init THIRDPARTY && \
     cp -r THIRDPARTY/All/* /thirdparty && \
-    cp -r THIRDPARTY/Linux/64bit/* /thirdparty && \
+    cp -r THIRDPARTY/Linux/x86_64/* /thirdparty && \
     chmod -R +x /thirdparty
 ENV PATH="/thirdparty/LuciPHOr2:/thirdparty/MSGFPlus:/thirdparty/Sirius:/thirdparty/ThermoRawFileParser:/thirdparty/Comet:/thirdparty/Fido:/thirdparty/MaRaCluster:/thirdparty/MyriMatch:/thirdparty/OMSSA:/thirdparty/Percolator:/thirdparty/SpectraST:/thirdparty/XTandem:/thirdparty/crux:${PATH}"
 
@@ -116,7 +116,7 @@ RUN pip install dist/*.whl
 
 # Install other dependencies (excluding pyopenms)
 COPY requirements.txt ./requirements.txt 
-RUN grep -v '^pyopenms' requirements.txt > requirements_cleaned.txt && mv requirements_cleaned.txt requirements.txt
+RUN grep -Ev '^pyopenms([=<>!~].*)?$' requirements.txt > requirements_cleaned.txt && mv requirements_cleaned.txt requirements.txt
 RUN pip install -r requirements.txt
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
 
 # Install up-to-date cmake via mamba and packages for pyOpenMS build.
 RUN mamba install cmake
-RUN pip install --upgrade pip && python -m pip install -U setuptools nose cython "autowrap<=0.24" pandas numpy pytest
+RUN pip install --upgrade pip && python -m pip install -U setuptools nose 'Cython>=3.1' 'autowrap==0.23.0' pandas 'numpy>=2.0' pytest
 
 # Clone OpenMS branch and the associcated contrib+thirdparties+pyOpenMS-doc submodules.
 RUN git clone --recursive --depth=1 -b ${OPENMS_BRANCH} --single-branch ${OPENMS_REPO} && cd /OpenMS
@@ -103,7 +103,7 @@ RUN mkdir /openms-build
 WORKDIR /openms-build
 
 # Configure.
-RUN /bin/bash -c "cmake -DCMAKE_BUILD_TYPE='Release' -DCMAKE_PREFIX_PATH='/OpenMS/contrib-build/;/usr/;/usr/local' -DHAS_XSERVER=OFF -DBOOST_USE_STATIC=OFF -DPYOPENMS=ON ../OpenMS -DPY_MEMLEAK_DISABLE=On DOPENMP=ON"
+RUN /bin/bash -c "cmake -DCMAKE_BUILD_TYPE='Release' -DCMAKE_PREFIX_PATH='/OpenMS/contrib-build/;/usr/;/usr/local' -DHAS_XSERVER=OFF -DBOOST_USE_STATIC=OFF -DPYOPENMS=ON ../OpenMS -DPY_MEMLEAK_DISABLE=On -DOPENMP=ON"
 
 # Build TOPP tools and clean up.
 RUN make -j4 TOPP

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ matplotlib==3.10.1
     # via pyopenms
 narwhals==1.32.0
     # via altair
-numpy==1.26.4
+numpy>=2.0
     # via
     #   contourpy
     #   matplotlib


### PR DESCRIPTION
## Summary
This PR upgrades the project to use OpenMS 3.5.0 and Qt 6, along with corresponding updates to build configurations and dependencies across Windows and Linux environments.

## Key Changes

- **OpenMS Version**: Updated from 3.2.0 to 3.5.0
- **Qt Framework**: Upgraded from Qt 5.15.2 to Qt 6.8.3
  - Updated Windows build action from `jurplel/install-qt-action@v3` to `v4`
  - Changed architecture specification to `win64_msvc2022_64`
  - Removed obsolete Qt 5 specific configuration parameters
- **Linux Dependencies**: Updated Qt packages from Qt 5 to Qt 6
  - Changed from `qtbase5-dev libqt5svg5-dev libqt5opengl5-dev` to `qt6-base-dev libqt6svg6-dev libqt6opengl6-dev libqt6openglwidgets6 libgl-dev`
- **Build Paths**: Updated THIRDPARTY directory references from `64bit` to `x86_64` naming convention in both Windows and Linux builds
- **Python Dependencies**: Relaxed version constraints in Dockerfile
  - Removed pinned versions for `Cython` and `numpy`
  - Updated `autowrap` constraint from `<0.23` to `<=0.24`
- **Requirements Filtering**: Improved regex pattern for filtering pyopenms from requirements.txt to handle version specifiers correctly

## Notable Implementation Details

- The Qt 6 upgrade requires MSVC 2022 compiler on Windows, reflecting modernization of the build toolchain
- THIRDPARTY path changes align with updated OpenMS directory structure conventions
- Python dependency relaxation allows for better compatibility with newer package versions while maintaining stability

https://claude.ai/code/session_0178Y5KgGPyEhxUrh888CM5V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenMS to 3.5.0.
  * Upgraded Qt from v5 to v6 and aligned build tooling.
  * Relaxed and updated Python dependency constraints (autowrap, Cython, numpy) for compatibility.
  * Adjusted third-party binary handling for Windows and Linux architecture paths.
  * Enabled OpenMP in native builds and refined build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->