### PR TITLE
Remove unused GITHUB_TOKEN build argument from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ COPY --from=js-build openms-streamlit-vue-component/dist /app/js-component/dist
 ARG OPENMS_REPO=https://github.com/t0mdavid-m/OpenMS.git
 ARG OPENMS_BRANCH=FVdeploy
 ARG PORT=8501
-# GitHub token to download latest OpenMS executable for Windows from Github action artifact.
-ARG GITHUB_TOKEN
 # Streamlit app Gihub user name (to download artifact from).
 ARG GITHUB_USER=OpenMS
 # Streamlit app Gihub repository name (to download artifact from).

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -30,8 +30,6 @@ COPY --from=js-build openms-streamlit-vue-component/dist /app/js-component/dist
 ARG OPENMS_REPO=https://github.com/t0mdavid-m/OpenMS.git
 ARG OPENMS_BRANCH=FVdeploy
 ARG PORT=8501
-# GitHub token to download latest OpenMS executable for Windows from Github action artifact.
-ARG GITHUB_TOKEN
 # Streamlit app Gihub user name (to download artifact from).
 ARG GITHUB_USER=OpenMS
 # Streamlit app Gihub repository name (to download artifact from).


### PR DESCRIPTION
## Summary

Removes the unused `GITHUB_TOKEN` build argument from both `Dockerfile` and `Dockerfile.arm`. This argument was declared but never referenced in the build process.

## Changes

- Removed `ARG GITHUB_TOKEN` declaration and its associated comment from `Dockerfile`
- Removed `ARG GITHUB_TOKEN` declaration and its associated comment from `Dockerfile.arm`

## Details

The `GITHUB_TOKEN` argument was previously documented as being used "to download latest OpenMS executable for Windows from Github action artifact," but this functionality is not actually utilized in the current Docker build configuration. The `GITHUB_USER` and `GITHUB_REPO` arguments remain, as they are still in use for artifact downloads.

This cleanup reduces unnecessary build arguments and potential security concerns around token handling in Docker builds.

https://claude.ai/code/session_015kE3xopcwc6muQr9dfrLtY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Docker build configuration to support configurable OpenMS source repository, branch, and container port settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/FLASHApp/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->