### PR TITLE
Fix cache path and add null-safety to sequence data rendering

### DIFF
--- a/content/FLASHDeconv/FLASHDeconvLayoutManager.py
+++ b/content/FLASHDeconv/FLASHDeconvLayoutManager.py
@@ -37,7 +37,7 @@ COMPONENT_NAMES=[
 # Setup cache access
 file_manager = FileManager(
     st.session_state["workspace"],
-    Path(st.session_state['workspace'], 'flashdeconv', 'cache')
+    Path(st.session_state['workspace'], 'cache')
 )
 
 def get_sequence():

--- a/src/render/update.py
+++ b/src/render/update.py
@@ -16,7 +16,7 @@ def get_sequence(selection_store):
     # Setup cache access
     file_manager = FileManager(
         st.session_state["workspace"],
-        Path(st.session_state['workspace'], 'flashdeconv', 'cache')
+        Path(st.session_state['workspace'], 'cache')
     )
 
     # Check if sequence has been set
@@ -85,18 +85,24 @@ def render_internal_fragment_data(sequence):
 def update_data(data, out_components, selection_store, additional_data, tool):
     component = out_components[0][0]['componentArgs']['title']
     if (
-        (component in ['Sequence View', 'Internal Fragment Map']) 
+        (component in ['Sequence View', 'Internal Fragment Map'])
         and (tool != 'flashtnt')
     ):
-        data['sequence_data'] = {
-            0: render_sequence_data(get_sequence(selection_store)[0])
-        }
-    if (component == 'Internal Fragment Map') and (tool != 'flashtnt'):
-        data['internal_fragment_data'] = {
-            0: render_internal_fragment_data(get_sequence(selection_store)[0])
-        }
-    
-    return data  
+        sequence = get_sequence(selection_store)
+        if sequence is None:
+            data['sequence_data'] = {}
+            if component == 'Internal Fragment Map':
+                data['internal_fragment_data'] = {}
+        else:
+            data['sequence_data'] = {
+                0: render_sequence_data(sequence[0])
+            }
+            if component == 'Internal Fragment Map':
+                data['internal_fragment_data'] = {
+                    0: render_internal_fragment_data(sequence[0])
+                }
+
+    return data
 
 
 def filter_data(data, out_components, selection_store, additional_data, tool):


### PR DESCRIPTION
## Summary

This PR fixes the cache directory path structure and adds null-safety checks to the sequence data rendering logic in the update module. The changes ensure the application gracefully handles cases where sequence data is unavailable.

## Key Changes

- **Cache path simplification**: Changed cache path from `'flashdeconv/cache'` to `'cache'` in both `src/render/update.py` and `content/FLASHDeconv/FLASHDeconvLayoutManager.py`. This aligns the cache directory structure with the workspace organization.

- **Null-safety for sequence data**: Refactored `update_data()` function to handle cases where `get_sequence()` returns `None`:
  - Calls `get_sequence()` once and stores the result to avoid redundant calls
  - Returns empty dictionaries for `sequence_data` and `internal_fragment_data` when sequence is unavailable
  - Maintains existing behavior when sequence data is present

- **Code cleanup**: Fixed trailing whitespace and improved code formatting for consistency

## Implementation Details

The sequence data rendering now follows a defensive programming pattern:
1. Retrieve sequence once at the start of the conditional block
2. Check if sequence is `None` before attempting to render
3. Populate empty data structures when sequence is unavailable, preventing downstream errors
4. Only render fragment data when the component is 'Internal Fragment Map'

This prevents potential `TypeError` exceptions when trying to access `sequence[0]` on a `None` value.

https://claude.ai/code/session_01J1rbXX85Rs3K7gENQPUYmB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cache storage directory structure
  * Optimized data processing for sequence view and internal fragment map components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/FLASHApp/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->