### PR TITLE
Configure prod k8s overlay for FLASHApp deployment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,7 +76,7 @@ jobs:
             type=ref,event=branch,suffix=-${{ matrix.variant }}
             type=ref,event=tag,suffix=-${{ matrix.variant }}
             type=sha,prefix=,suffix=-${{ matrix.variant }}
-            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
 
       - name: Build and conditionally push
         uses: docker/build-push-action@v5
@@ -303,7 +303,7 @@ jobs:
             type=ref,event=branch,suffix=-${{ matrix.variant }}
             type=ref,event=tag,suffix=-${{ matrix.variant }}
             type=sha,prefix=,suffix=-${{ matrix.variant }}
-            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
 
       - name: Log in to GHCR for ORAS push
         env:

--- a/k8s/base/workspace-pvc.yaml
+++ b/k8s/base/workspace-pvc.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: cinder-csi
   resources:
     requests:
-      storage: 500Gi
+      storage: 3Ti

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -5,17 +5,17 @@ resources:
   - ../../base
 
 components:
-  - ../../components/memory-tier-low
+  - ../../components/memory-tier-high
 
-namePrefix: template-app-
+namePrefix: flashapp-
 
 commonLabels:
-  app: template-app
+  app: flashapp
 
 images:
   - name: openms-streamlit
-    newName: ghcr.io/openms/streamlit-template
-    newTag: main-full
+    newName: ghcr.io/openms/flashapp
+    newTag: latest
 
 patches:
   - target:
@@ -24,21 +24,24 @@ patches:
     patch: |
       - op: replace
         path: /spec/routes/0/match
-        value: (Host(`template.webapps.openms.de`) || Host(`template.webapps.openms.org`)) && PathPrefix(`/`)
+        value: (Host(`flashapp.webapps.openms.de`) || Host(`flashapp.webapps.openms.org`)) && PathPrefix(`/`)
       - op: replace
         path: /spec/routes/0/services/0/name
-        value: template-app-streamlit
+        value: flashapp-streamlit
   - target:
       kind: Deployment
       name: streamlit
     patch: |
       - op: replace
         path: /spec/template/spec/containers/0/env/0/value
-        value: "redis://template-app-redis:6379/0"
+        value: "redis://flashapp-redis:6379/0"
   - target:
       kind: Deployment
       name: rq-worker
     patch: |
       - op: replace
+        path: /spec/replicas
+        value: 5
+      - op: replace
         path: /spec/template/spec/containers/0/env/0/value
-        value: "redis://template-app-redis:6379/0"
+        value: "redis://flashapp-redis:6379/0"


### PR DESCRIPTION
## Summary

Wire the prod Kustomize overlay to actually deploy **FLASHApp** instead of the inherited `template-app` placeholders, plus a few sizing knobs and a CI fix needed for `:latest` to exist at all on this fork.

### Overlay (`k8s/overlays/prod/kustomization.yaml`)
- `namePrefix` and `commonLabels.app`: `template-app` → `flashapp`
- Image: `ghcr.io/openms/streamlit-template:main-full` → `ghcr.io/openms/flashapp:latest`
- IngressRoute hosts: `template.webapps.openms.{de,org}` → `flashapp.webapps.openms.{de,org}`
- IngressRoute service ref + both Redis URL patches updated to `flashapp-*`
- Memory tier component: `memory-tier-low` → `memory-tier-high`
- New patch op: `rq-worker` Deployment `replicas: 1` → `5`

### Base (`k8s/base/workspace-pvc.yaml`)
- Workspace PVC: `500Gi` → `3Ti` (PVC name and `claimName` untouched so kustomize still scopes it to `flashapp-workspaces-pvc`)

### CI (`.github/workflows/build-and-test.yml`)
- Flip the `latest`-tag enable gate from `refs/heads/main` → `refs/heads/develop` for both the OCI image (line 79) and the Apptainer SIF (line 306). FLASHApp's CI only triggers on `develop` pushes and `v*` tags, so without this change `:latest` would never get published and `ImagePullBackOff` would block the cluster.

## Operator notes (post-merge)

1. Cluster operator runs `kubectl apply -k k8s/overlays/prod/` against the OpenMS cluster.
2. Verify rollout: `kubectl -n openms rollout status deployment/flashapp-streamlit deployment/flashapp-rq-worker`.
3. Browser-check `https://flashapp.webapps.openms.de` (and `.org`).
4. Future develop merges: re-apply isn't enough — `:latest` doesn't trigger a rollout on its own. Run `kubectl -n openms rollout restart deployment/flashapp-streamlit deployment/flashapp-rq-worker` after each CI run to pick up the rebuilt image.

## Caveats

- **RWO PVC co-location**: `workspaces-pvc` is `ReadWriteOnce`. After rollout, 2 streamlit + 5 rq-worker = 7 pods must share one node. If pods sit `Pending`, scale rq-worker back down or switch the storage class to RWX.
- **`memory-tier-high`**: requires worker nodes labelled `openms.de/memory-tier=high`. Confirms with cluster admin that capacity exists alongside the existing heavy DIA apps.
- **3Ti PVC**: needs 3Ti free in `cinder-csi`. In-place expansion of an already-deployed PVC requires `allowVolumeExpansion: true` on the StorageClass — recreate, don't edit, if expansion isn't allowed.

## Test plan

- [ ] CI `lint-manifests` passes against the rewritten overlay
- [ ] CI `build` job publishes `ghcr.io/openms/flashapp:latest` (verify on GHCR after merge)
- [ ] CI `publish-apptainer` job publishes `ghcr.io/openms/flashapp/sif:latest`
- [ ] CI `test-traefik` / `test-nginx` kind jobs come up under the new `flashapp-` resource names
- [ ] Cluster `kubectl apply -k` succeeds; pods reach Ready
- [ ] `https://flashapp.webapps.openms.de` and `https://flashapp.webapps.openms.org` both serve the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to publish latest image tags on develop branch
  * Increased workspace storage capacity from 500GB to 3TB
  * Updated production environment configuration and deployment settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/FLASHApp/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->