### PR TITLE
Handle empty dataframes in downsample_heatmap to prevent scipy crash

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,37 @@
+name: Unit Tests
+
+# Runs the Python unit tests in tests/ (pytest). This is intentionally
+# separate from build-and-test.yml, whose "test" jobs are container/k8s
+# deployment smoke tests rather than pytest.
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Match the runtime built in the Dockerfile (python=3.11).
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Pinned runtime deps (pyopenms is needed so ParameterManager imports
+          # cleanly at collection time) plus test-only deps. fakeredis backs the
+          # QueueManager/WorkflowManager tests, which pytest.importorskip it.
+          pip install -r requirements.txt
+          pip install pytest fakeredis
+
+      - name: Run unit tests
+        run: pytest tests/ -v

--- a/src/render/compression.py
+++ b/src/render/compression.py
@@ -51,6 +51,13 @@ def downsample_heatmap(data, max_datapoints=20000, rt_bins=400, mz_bins=50, logg
 
     # We need to collect here because scipy requires numpy arrays
     sorted_data = sorted_data.collect()
+
+    # scipy's binned_statistic_2d reduces over the inputs to derive bin edges
+    # and raises "zero-size array to reduction operation minimum" on empty
+    # input. With no peaks there is nothing to downsample, so return the input
+    # unchanged (same schema, zero rows).
+    if sorted_data.is_empty():
+        return data
     
     # Count peaks
     total_count = sorted_data.select(pl.count()).item()

--- a/tests/test_render_compression.py
+++ b/tests/test_render_compression.py
@@ -1,0 +1,50 @@
+"""
+Tests for downsample_heatmap, the heatmap point-reduction helper.
+
+The deconvolved-heatmap panels are built per MS level, and a level with no
+peaks (e.g. an MS1-only run that still shows an MS2 panel) yields an empty
+frame. That empty frame used to reach scipy's binned_statistic_2d, which
+raises "zero-size array to reduction operation minimum which has no identity"
+while computing bin edges. downsample_heatmap must short-circuit on empty
+input and return an empty, schema-preserving frame instead of crashing.
+
+The helper is pure polars/numpy/scipy (no Streamlit), so it is unit-testable
+without booting the app.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import polars as pl
+
+from src.render.compression import downsample_heatmap
+
+
+HEATMAP_SCHEMA = {"mass": pl.Float64, "rt": pl.Float64, "intensity": pl.Float64}
+
+
+def test_empty_dataframe_returns_empty_with_schema():
+    result = downsample_heatmap(pl.DataFrame(schema=HEATMAP_SCHEMA)).collect()
+    assert result.is_empty()
+    assert set(result.columns) >= {"mass", "rt", "intensity"}
+
+
+def test_empty_lazyframe_returns_empty_with_schema():
+    result = downsample_heatmap(pl.LazyFrame(schema=HEATMAP_SCHEMA)).collect()
+    assert result.is_empty()
+    assert set(result.columns) >= {"mass", "rt", "intensity"}
+
+
+def test_nonempty_input_passes_through_binning():
+    df = pl.DataFrame(
+        {
+            "mass": [100.0, 200.0, 300.0],
+            "rt": [1.0, 2.0, 3.0],
+            "intensity": [10.0, 20.0, 30.0],
+        }
+    )
+    result = downsample_heatmap(df).collect()
+    assert set(result.columns) >= {"mass", "rt", "intensity"}
+    assert result.height <= df.height


### PR DESCRIPTION
## Summary

Fixes a crash in `downsample_heatmap` when processing MS levels with no peaks (e.g., an MS1-only run that still renders an MS2 panel). The function now gracefully handles empty input by short-circuiting before calling scipy's `binned_statistic_2d`, which raises an error on zero-size arrays.

## Changes

- **src/render/compression.py**: Added an early return in `downsample_heatmap()` to detect empty input after collecting the sorted data and return the input unchanged (preserving schema with zero rows) instead of passing it to scipy
- **tests/test_render_compression.py**: Added comprehensive unit tests covering:
  - Empty DataFrame input returns empty result with correct schema
  - Empty LazyFrame input returns empty result with correct schema  
  - Non-empty input still passes through the binning logic correctly

## Implementation Details

The fix checks `sorted_data.is_empty()` after collecting the lazy frame but before scipy operations. When empty, it returns the original `data` parameter unchanged, which preserves the schema (mass, rt, intensity columns) while maintaining zero rows. This allows downstream code to handle empty panels gracefully without crashing.

The tests are pure unit tests (polars/numpy/scipy, no Streamlit) and can run independently of the app.

https://claude.ai/code/session_01NrxFNaVYUhjrLJ8HiS1ZZK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heatmap rendering to gracefully handle empty datasets without errors while preserving data schema integrity.

* **Tests**
  * Added comprehensive test coverage for heatmap rendering, validating correct handling of empty and non-empty datasets with proper data structure preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/FLASHApp/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->