### PR TITLE
Disable internal fragment map component

### DIFF
--- a/content/FLASHTnT/FLASHTnTLayoutManager.py
+++ b/content/FLASHTnT/FLASHTnTLayoutManager.py
@@ -9,7 +9,7 @@ from pathlib import Path
 COMPONENT_OPTIONS=[
     'Protein table',
     'Sequence view (Protein table needed)',
-    'Internal fragment map (Protein table needed)',
+    # 'Internal fragment map (Protein table needed)',  # Disabled - re-enable together with COMPONENT_NAMES entry below
     'Tag table (Protein table needed)',
     'Sequence tag view (Tag table needed)',
     'Score Distribution Plot',
@@ -20,7 +20,7 @@ COMPONENT_OPTIONS=[
 COMPONENT_NAMES=[
     'protein_table', 
     'sequence_view', 
-    'internal_fragment_map',
+    # 'internal_fragment_map',  # Disabled - re-enable together with COMPONENT_OPTIONS entry above
     'tag_table',
     'combined_spectrum',
     'id_fdr_plot',

--- a/content/FLASHTnT/FLASHTnTViewer.py
+++ b/content/FLASHTnT/FLASHTnTViewer.py
@@ -47,7 +47,7 @@ file_manager = FileManager(
     Path(st.session_state['workspace'], 'cache')
 )
 results = file_manager.get_results_list(
-    ['internal_fragment_data']
+    ['protein_dfs']
 )
 
 if file_manager.result_exists('layout', 'layout'):

--- a/src/parse/tnt.py
+++ b/src/parse/tnt.py
@@ -80,7 +80,7 @@ def parseTnT(file_manager, dataset_id, deconv_mzML, anno_mzML, tag_tsv, protein_
 
     # sequence_view & internal_fragment_map
     sequence_data = {}
-    internal_fragment_data = {}
+    # internal_fragment_data = {}  # Disabled
     # Compute coverage
     for i, row in protein_df.iterrows():
         pid = row['index']
@@ -140,14 +140,14 @@ def parseTnT(file_manager, dataset_id, deconv_mzML, anno_mzML, tag_tsv, protein_
             } for s, e, m, l in zip(mod_starts, mod_ends, mod_masses, mod_labels)
         ]
 
-        internal_fragment_data[pid] = getInternalFragmentDataFromSeq(
-            str(sequence)[start_index:end_index+1], modifications
-        )  
+        # internal_fragment_data[pid] = getInternalFragmentDataFromSeq(
+        #     str(sequence)[start_index:end_index+1], modifications
+        # )  # Disabled
 
     file_manager.store_data(dataset_id, 'sequence_data', sequence_data)
-    file_manager.store_data(
-        dataset_id, 'internal_fragment_data', internal_fragment_data
-    )
+    # file_manager.store_data(
+    #     dataset_id, 'internal_fragment_data', internal_fragment_data
+    # )  # Disabled
     logger.log("70.0 %", level=2)
 
     fragments = ['b', 'y']

--- a/src/render/initialize.py
+++ b/src/render/initialize.py
@@ -136,15 +136,15 @@ def initialize_data(comp_name, selected_data, file_manager, tool):
             data = file_manager.get_results(selected_data,  ['settings'])
             data_to_send['settings'] = data['settings']
         component_arguments = SequenceView(title='Sequence View')
-    elif comp_name == 'internal_fragment_map':
-        data = file_manager.get_results(selected_data,  ['sequence_view'])
-        data_to_send['per_scan_data'] = data['sequence_view']
-        if tool == 'flashtnt':
-            data = file_manager.get_results(selected_data,  ['sequence_data'])
-            data_to_send['sequence_data'] = data['sequence_data']
-            data = file_manager.get_results(selected_data,  ['internal_fragment_data'])
-            data_to_send['internal_fragment_data'] = data['internal_fragment_data']
-        component_arguments = InternalFragmentMap(title="Internal Fragment Map")    
+    # elif comp_name == 'internal_fragment_map':
+    #     data = file_manager.get_results(selected_data,  ['sequence_view'])
+    #     data_to_send['per_scan_data'] = data['sequence_view']
+    #     if tool == 'flashtnt':
+    #         data = file_manager.get_results(selected_data,  ['sequence_data'])
+    #         data_to_send['sequence_data'] = data['sequence_data']
+    #         data = file_manager.get_results(selected_data,  ['internal_fragment_data'])
+    #         data_to_send['internal_fragment_data'] = data['internal_fragment_data']
+    #     component_arguments = InternalFragmentMap(title="Internal Fragment Map")
     elif comp_name == 'fdr_plot':
         data = file_manager.get_results(selected_data,  ['density_target'])
         data_to_send['density_target'] = data['density_target']


### PR DESCRIPTION
## Summary
Disables the internal fragment map visualization component across the FLASHTnT application. This component is being temporarily removed from the UI and data processing pipeline.

## Changes
- **src/render/initialize.py**: Commented out the `internal_fragment_map` component initialization block that handled data loading for sequence view and internal fragment data
- **src/parse/tnt.py**: Disabled internal fragment data computation and storage:
  - Commented out `internal_fragment_data` dictionary initialization
  - Commented out the `getInternalFragmentDataFromSeq()` call that populated internal fragment data
  - Commented out the `file_manager.store_data()` call that persisted internal fragment data
- **content/FLASHTnT/FLASHTnTLayoutManager.py**: Removed internal fragment map from both `COMPONENT_OPTIONS` and `COMPONENT_NAMES` lists with inline comments indicating it should be re-enabled together with the corresponding entry
- **content/FLASHTnT/FLASHTnTViewer.py**: Changed the results list query from `['internal_fragment_data']` to `['protein_dfs']` to reflect disabled component

## Implementation Details
All changes use inline comments (`# Disabled`) to mark disabled code sections, making it straightforward to re-enable this functionality in the future. The component removal is consistent across the data pipeline (parsing), initialization, and UI configuration layers.

https://claude.ai/code/session_01PwtD8no1MKLH86UpGCFcCk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the internal fragment map feature from component selection and data processing pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/FLASHApp/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->