### PR TITLE
Refactor cache path and standardize layout storage keys

### DIFF
--- a/content/FLASHTnT/FLASHTnTLayoutManager.py
+++ b/content/FLASHTnT/FLASHTnTLayoutManager.py
@@ -31,11 +31,11 @@ COMPONENT_NAMES=[
 # Setup cache access
 file_manager = FileManager(
     st.session_state["workspace"],
-    Path(st.session_state['workspace'], 'flashtnt', 'cache')
+    Path(st.session_state['workspace'], 'cache')
 )
 
 def set_layout(layout, side_by_side=False):
-    file_manager.store_data('layout', 'layout', 
+    file_manager.store_data('flashtnt_layout', 'layout',
         {
             'layout': layout,
             'side_by_side': side_by_side
@@ -44,20 +44,20 @@ def set_layout(layout, side_by_side=False):
 
 def get_layout():
     # Check if layout has been set
-    if not file_manager.result_exists('layout', 'layout'):
+    if not file_manager.result_exists('flashtnt_layout', 'layout'):
         return None
     # fetch layout from cache
-    layout = file_manager.get_results('layout', 'layout')['layout']
+    layout = file_manager.get_results('flashtnt_layout', 'layout')['layout']
 
-    return layout['layout'], layout['side_by_side'] 
+    return layout['layout'], layout['side_by_side']
 
 def resetSettingsToDefault(num_of_exp=1):
     st.session_state["layout_setting_tagger"] = [[['']]] # 1D: experiment, 2D: row, 3D: column, element=component name
     st.session_state["num_of_experiment_to_show_tagger"] = num_of_exp
     for index in range(1, num_of_exp):
         st.session_state.layout_setting_tagger.append([['']])
-    if file_manager.result_exists('layout', 'layout'):
-        file_manager.remove_results('layout')
+    if file_manager.result_exists('flashtnt_layout', 'layout'):
+        file_manager.remove_results('flashtnt_layout')
     st.session_state["edit_mode"] = True
 
 

--- a/content/FLASHTnT/FLASHTnTViewer.py
+++ b/content/FLASHTnT/FLASHTnTViewer.py
@@ -50,11 +50,11 @@ results = file_manager.get_results_list(
     ['internal_fragment_data']
 )
 
-if file_manager.result_exists('layout', 'layout'):
-    layout = file_manager.get_results('layout', 'layout')['layout']
+if file_manager.result_exists('flashtnt_layout', 'layout'):
+    layout = file_manager.get_results('flashtnt_layout', 'layout')['layout']
     side_by_side = layout['side_by_side']
     layout = layout['layout']
-    
+
 else:
     layout = [DEFAULT_LAYOUT]
     side_by_side = False


### PR DESCRIPTION
## Summary
This PR refactors the cache directory structure and standardizes the storage keys used for layout persistence in FLASHTnT, improving consistency and simplifying the file organization.

## Key Changes
- **Cache path simplification**: Changed cache directory from `workspace/flashtnt/cache` to `workspace/cache`, removing the redundant `flashtnt` subdirectory level
- **Storage key standardization**: Renamed layout storage key from `'layout'` to `'flashtnt_layout'` across all file manager operations to:
  - Avoid potential key collisions in shared cache directories
  - Provide clearer namespace separation for FLASHTnT-specific data
  - Improve maintainability when multiple tools share the same workspace
- **Code cleanup**: Fixed trailing whitespace in `get_layout()` return statement and removed trailing whitespace in `FLASHTnTViewer.py`

## Files Modified
- `content/FLASHTnT/FLASHTnTLayoutManager.py`: Updated cache path initialization and all layout storage/retrieval operations
- `content/FLASHTnT/FLASHTnTViewer.py`: Updated layout retrieval to use new storage key

## Implementation Details
All file manager calls (`store_data`, `result_exists`, `get_results`, `remove_results`) have been updated consistently to use the new `'flashtnt_layout'` key, ensuring layout persistence continues to work correctly across the application.

https://claude.ai/code/session_01YTN6PkcSfg2b21zHL7cYGg