### PR TITLE
CI: Free disk space in build-amd64 job to prevent OOM failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,24 @@ jobs:
           - variant: full
             dockerfile: Dockerfile
     steps:
+      - name: Free disk space
+        # `load: true` imports the built image into the docker daemon and the
+        # later `docker save` writes it out again, so the ~6-8 GB image needs
+        # roughly 3x its size on disk. ubuntu-latest's default free space isn't
+        # enough, so the build dies at "importing to docker" with
+        # "no space left on device". Mirrors the build-arm64 job below.
+        run: |
+          # /opt/hostedtoolcache/CodeQL is ~5 GB and unused here; keep the rest
+          # of hostedtoolcache to stay consistent with build-arm64.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/.ghcup /usr/share/swift \
+                      /usr/local/share/boost \
+                      /opt/hostedtoolcache/CodeQL || true
+          sudo apt-get clean
+          # Pre-installed docker images aren't used by this build job.
+          sudo docker image prune --all --force || true
+          df -h
+
       - uses: actions/checkout@v4
 
       - name: Compute lowercase image name (OCI refs must be lowercase)


### PR DESCRIPTION
## Summary

Adds disk space cleanup to the `build-amd64` job in the GitHub Actions CI workflow to prevent "no space left on device" errors during Docker image builds. The build process requires ~3x the final image size (~18-24 GB total) due to intermediate layers and the `docker save` operation, which exceeds the default free space on `ubuntu-latest` runners.

## Changes

- **Disk cleanup step**: Removes unused system packages and pre-installed tools:
  - `/usr/share/dotnet` — .NET SDK (~2 GB)
  - `/usr/local/lib/android` — Android SDK (~5 GB)
  - `/opt/ghc` — GHC Haskell compiler (~5 GB)
  - `/usr/local/.ghcup` — GHCup toolchain manager
  - `/usr/share/swift` — Swift compiler
  - `/usr/local/share/boost` — Boost libraries
  - `/opt/hostedtoolcache/CodeQL` — CodeQL (~5 GB, unused in this job)
  - Pre-installed Docker images via `docker image prune`
  - APT package cache via `apt-get clean`

- **Mirrors existing pattern**: Matches the disk cleanup already present in the `build-arm64` job for consistency

- **Diagnostic output**: Includes `df -h` to verify available space after cleanup

## Implementation Details

- Cleanup runs before `actions/checkout@v4` to free space early in the workflow
- Uses `|| true` to prevent workflow failure if any cleanup command fails (e.g., if a path doesn't exist)
- Preserves most of `/opt/hostedtoolcache` except CodeQL to maintain consistency with `build-arm64`
- Provides detailed comments explaining the rationale for each cleanup operation

https://claude.ai/code/session_01UNTgnLWWbyrH6k5j4yGdUx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline stability for builds.

**Note:** This release contains infrastructure improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/FLASHApp/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->