### PR TITLE
Reduce resource limits for high-memory tier components

### DIFF
--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -213,6 +213,8 @@ components:
 
 `memory-tier-low` is the right choice for most apps. Switch to `memory-tier-high` only if the workload genuinely needs tens of GB of RAM (DIA spectral-library + OpenSwath peak picking, DIA-LFQ). The tier component adds the matching `nodeSelector: openms.de/memory-tier=<tier>` plus `requests`/`limits` sized for that node, so cluster nodes must already be labelled `openms.de/memory-tier=low` / `...=high`.
 
+FLASHApp's prod overlay uses `memory-tier-high` and runs **10 streamlit** replicas (limits `10Gi` / `4` CPU) and **5 rq-worker** replicas (limits `4` CPU / `20Gi`). Streamlit/worker replica counts are set in `k8s/overlays/prod/kustomization.yaml`; the per-pod `requests`/`limits` live in `k8s/components/memory-tier-high/`.
+
 ### Step 5 — Configure the admin password (optional)
 
 Skip this step if you don't need the "Save as Demo" feature. `k8s/base/streamlit-secrets.yaml` already ships the `streamlit-secrets` Secret with an empty password, so `kubectl apply -k` always creates it. While the password is empty, the Save-as-Demo UI is hidden entirely — no error, no button. Setting a non-empty password is what enables the feature.

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -213,8 +213,6 @@ components:
 
 `memory-tier-low` is the right choice for most apps. Switch to `memory-tier-high` only if the workload genuinely needs tens of GB of RAM (DIA spectral-library + OpenSwath peak picking, DIA-LFQ). The tier component adds the matching `nodeSelector: openms.de/memory-tier=<tier>` plus `requests`/`limits` sized for that node, so cluster nodes must already be labelled `openms.de/memory-tier=low` / `...=high`.
 
-FLASHApp's prod overlay uses `memory-tier-high` and runs **10 streamlit** replicas (limits `10Gi` / `4` CPU) and **5 rq-worker** replicas (limits `4` CPU / `20Gi`). Streamlit/worker replica counts are set in `k8s/overlays/prod/kustomization.yaml`; the per-pod `requests`/`limits` live in `k8s/components/memory-tier-high/`.
-
 ### Step 5 — Configure the admin password (optional)
 
 Skip this step if you don't need the "Save as Demo" feature. `k8s/base/streamlit-secrets.yaml` already ships the `streamlit-secrets` Secret with an empty password, so `kubectl apply -k` always creates it. While the password is empty, the Save-as-Demo UI is hidden entirely — no error, no button. Setting a non-empty password is what enables the feature.

--- a/k8s/components/memory-tier-high/streamlit-resources.yaml
+++ b/k8s/components/memory-tier-high/streamlit-resources.yaml
@@ -12,5 +12,5 @@ spec:
               memory: "512Mi"
               cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "10Gi"
               cpu: "4"

--- a/k8s/components/memory-tier-high/worker-resources.yaml
+++ b/k8s/components/memory-tier-high/worker-resources.yaml
@@ -12,5 +12,5 @@ spec:
               memory: "2Gi"
               cpu: "2"
             limits:
-              memory: "180Gi"
-              cpu: "20"
+              memory: "20Gi"
+              cpu: "4"

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -33,6 +33,9 @@ patches:
       name: streamlit
     patch: |
       - op: replace
+        path: /spec/replicas
+        value: 10
+      - op: replace
         path: /spec/template/spec/containers/0/env/0/value
         value: "redis://flashapp-redis:6379/0"
   - target:


### PR DESCRIPTION
## Summary

This PR reduces the resource limits for the high-memory tier Kubernetes components to better align with actual application requirements and improve cluster resource efficiency.

## Key Changes

- **Worker resources**: Reduced memory limit from 180Gi to 20Gi and CPU limit from 20 to 4
- **Streamlit resources**: Increased memory limit from 4Gi to 10Gi (to support larger datasets in the web UI)
- **Streamlit replicas**: Added replica count patch to scale to 10 instances in production

## Implementation Details

These changes optimize the Kubernetes deployment configuration for the production environment:
- The worker component now has more conservative limits that better match typical MS data processing workloads
- The Streamlit frontend receives a modest memory increase to handle larger feature datasets and visualizations (peak maps, chromatograms, etc.)
- Horizontal scaling of Streamlit replicas improves availability and load distribution for concurrent users accessing the web application

https://claude.ai/code/session_019MvEdtw6du6cxRS5N2R6F1