### PR TITLE
Set FLASHTnT tag length defaults to 4 in workflow configuration

### DIFF
--- a/src/Workflow.py
+++ b/src/Workflow.py
@@ -78,7 +78,12 @@ class TagWorkflow(WorkflowManager):
             )
         with t[1]:
             # FLASHTnT Configuration
-            self.ui.input_TOPP('FLASHTnT', display_subsections=True, display_tool_name=False)
+            self.ui.input_TOPP(
+                'FLASHTnT',
+                display_subsections=True,
+                display_tool_name=False,
+                custom_defaults={'tag:min_length': 4, 'tag:max_length': 4},
+            )
 
 
     def execution(self) -> None:


### PR DESCRIPTION
## Summary
Updated the FLASHTnT TOPP tool configuration in the workflow to set default tag length parameters, improving the default behavior for top-down proteomics analysis.

## Changes
- Added `custom_defaults` parameter to the `input_TOPP()` call for FLASHTnT
- Set both `tag:min_length` and `tag:max_length` to 4 as default values
- Reformatted the function call across multiple lines for improved readability

## Implementation Details
The change leverages the `custom_defaults` parameter of `StreamlitUI.input_TOPP()` to override the tool's default tag length parameters. This ensures that users working with FLASHTnT (the deconvolution tool used in top-down proteomics workflows) start with a sensible default configuration for tag-based analysis, reducing the need for manual parameter adjustment in typical use cases.

https://claude.ai/code/session_01KSamWUKpmRXxHYTmCmNdR8