### PR TITLE
perf(flashtnt): lazy per-scan parquet loading via row-group pushdown

### DIFF
--- a/src/parse/deconv.py
+++ b/src/parse/deconv.py
@@ -6,6 +6,10 @@ from src.parse.masstable import parseFLASHDeconvOutput, getMSSignalDF, getSpectr
 from src.render.compression import downsample_heatmap, compute_compression_levels
 from scipy.stats import gaussian_kde
 
+# One row per scan with heavy array-valued cells; small row groups so per-scan
+# pushdown reads only the matching group(s) instead of the whole file.
+SPECTRA_ROW_GROUP_SIZE = 64
+
 def parseDeconv(
         file_manager, dataset_id, out_deconv_mzML, anno_annotated_mzML, 
         spec1_tsv=None, spec2_tsv=None, logger=None
@@ -105,7 +109,7 @@ def parseDeconv(
         ])
         .sort("index")
     )
-    file_manager.store_data(dataset_id, 'anno_spectrum', anno_spectrum_lazy)
+    file_manager.store_data(dataset_id, 'anno_spectrum', anno_spectrum_lazy, row_group_size=SPECTRA_ROW_GROUP_SIZE)
 
     logger.log("40.0 %", level=2)
 
@@ -126,7 +130,7 @@ def parseDeconv(
         ])
         .sort("index")
     )
-    file_manager.store_data(dataset_id, 'mass_table', mass_table_lazy)
+    file_manager.store_data(dataset_id, 'mass_table', mass_table_lazy, row_group_size=SPECTRA_ROW_GROUP_SIZE)
 
     logger.log("50.0 %", level=2)
 
@@ -140,7 +144,7 @@ def parseDeconv(
         ])
         .sort("index")
     )
-    file_manager.store_data(dataset_id, 'sequence_view', sequence_view_lazy)
+    file_manager.store_data(dataset_id, 'sequence_view', sequence_view_lazy, row_group_size=SPECTRA_ROW_GROUP_SIZE)
 
     logger.log("60.0 %", level=2)
 
@@ -154,7 +158,7 @@ def parseDeconv(
         ])
         .sort("index")
     )
-    file_manager.store_data(dataset_id, 'deconv_spectrum', deconv_spectrum_lazy)
+    file_manager.store_data(dataset_id, 'deconv_spectrum', deconv_spectrum_lazy, row_group_size=SPECTRA_ROW_GROUP_SIZE)
 
     logger.log("70.0 %", level=2)
 
@@ -178,7 +182,7 @@ def parseDeconv(
         )
         .sort("index")
     )
-    file_manager.store_data(dataset_id, 'combined_spectrum', combined_spectrum_lazy)
+    file_manager.store_data(dataset_id, 'combined_spectrum', combined_spectrum_lazy, row_group_size=SPECTRA_ROW_GROUP_SIZE)
 
     logger.log("80.0 %", level=2)
 

--- a/src/parse/tnt.py
+++ b/src/parse/tnt.py
@@ -15,6 +15,10 @@ from src.render.sequence import (
     remove_ambigious, getFragmentDataFromSeq, getInternalFragmentDataFromSeq
 )
 
+# Many thin rows (one per tag); sort by Scan so row groups carry contiguous
+# scan ranges and per-scan pushdown can skip non-matching groups.
+TAG_ROW_GROUP_SIZE = 16384
+
 
 def _coverage_from_ranges(starts, ends, seq_len):
     """Per-residue coverage: number of tags whose inclusive [StartPos, EndPos]
@@ -106,7 +110,8 @@ def parseTnT(file_manager, dataset_id, deconv_mzML, anno_mzML, tag_tsv, protein_
             'StartPosition' : 'StartPos' 
         }
     )
-    file_manager.store_data(dataset_id, 'tag_dfs', tag_df)
+    tag_df = tag_df.sort_values('Scan', kind='stable', ignore_index=True)
+    file_manager.store_data(dataset_id, 'tag_dfs', tag_df, row_group_size=TAG_ROW_GROUP_SIZE)
     logger.log("50.0 %", level=2)
 
     # sequence_view & internal_fragment_map

--- a/src/render/initialize.py
+++ b/src/render/initialize.py
@@ -18,16 +18,16 @@ def _attach_proteoform_scan_map(file_manager, selected_data, additional_data):
 
 
 def _load_scan_scoped(file_manager, selected_data, cache_name, tool, additional_data):
-    """Eager-load the cache once (cached in session_state by the caller). For
-    flashtnt also attach the proteoform->scan map so filter_data can slice the
-    selected proteoform's scan in memory -- matching the FLASHDeconv path, which
-    loads once and slices with iloc. (A per-click pyarrow pushdown was tried but
-    re-read the whole file every click: the per-scan caches are written as a
-    single parquet row group, so pushdown cannot skip rows.)"""
-    result = file_manager.get_results(selected_data, [cache_name])
+    """For flashtnt, return a pyarrow dataset handle (not a materialized frame)
+    plus the proteoform->scan map, so filter_data can push the selected scan
+    down to the parquet reader -- the per-scan caches are now written with
+    bounded row groups (see deconv.py / tnt.py), so pushdown skips non-matching
+    groups. Non-flashtnt keeps eager loading + in-memory iloc slicing."""
     if tool == 'flashtnt':
         _attach_proteoform_scan_map(file_manager, selected_data, additional_data)
-    return result[cache_name]
+        return file_manager.get_results(
+            selected_data, [cache_name], use_pyarrow=True)[cache_name]
+    return file_manager.get_results(selected_data, [cache_name])[cache_name]
 
 
 def initialize_data(comp_name, selected_data, file_manager, tool):

--- a/src/render/update.py
+++ b/src/render/update.py
@@ -121,11 +121,13 @@ def filter_data(data, out_components, selection_store, additional_data, tool):
         if tool == 'flashtnt':
             scan_map = additional_data.get('proteoform_scan_map', {})
             entry = scan_map.get(selection_store.get('proteinIndex'))
+            handle = data['per_scan_data']  # pyarrow dataset (lazy)
             if entry is None:
-                data['per_scan_data'] = data['per_scan_data'].iloc[0:0, :]
+                data['per_scan_data'] = handle.to_table(
+                    filter=ds.field('index') == -1).to_pandas()
             else:
-                per_scan = data['per_scan_data']
-                data['per_scan_data'] = per_scan[per_scan['index'] == entry['deconv_index']]
+                data['per_scan_data'] = handle.to_table(
+                    filter=ds.field('index') == entry['deconv_index']).to_pandas()
         elif 'scanIndex' not in selection_store:
             data['per_scan_data'] = data['per_scan_data'].iloc[0:0,:]
         else:
@@ -173,16 +175,19 @@ def filter_data(data, out_components, selection_store, additional_data, tool):
             additional_data['dataset'], component
         )
     elif component == 'Tag Table':
-        # flashtnt-only panel: tags are scan (spectrum) data. Scope to the
-        # selected proteoform's scan and stamp ProteinIndex so the frontend's
-        # tag.ProteinIndex===selectedProteinIndex filter passes all the scan's
-        # tags through to the table and the on-spectrum overlay.
+        # flashtnt-only panel: tags are scan (spectrum) data. Push the selected
+        # proteoform's scan down to the parquet reader and stamp ProteinIndex so
+        # the frontend's tag.ProteinIndex===selectedProteinIndex filter passes
+        # all the scan's tags to the table and the on-spectrum overlay.
         scan_map = additional_data.get('proteoform_scan_map', {})
         entry = scan_map.get(selection_store.get('proteinIndex'))
+        handle = data['tag_table']  # pyarrow dataset (lazy)
         if entry is None:
-            data['tag_table'] = data['tag_table'].iloc[0:0, :]
+            data['tag_table'] = handle.to_table(
+                filter=ds.field('Scan') == -1).to_pandas()
         else:
-            sel = data['tag_table'][data['tag_table']['Scan'] == entry['scan']].copy()
+            sel = handle.to_table(
+                filter=ds.field('Scan') == entry['scan']).to_pandas()
             sel['ProteinIndex'] = selection_store['proteinIndex']
             data['tag_table'] = sel
 

--- a/src/workflow/FileManager.py
+++ b/src/workflow/FileManager.py
@@ -289,38 +289,45 @@ class FileManager:
             DO UPDATE SET {column_name} = excluded.{column_name};
         """)
 
-    def _store_data(self, dataset_id: str, name_tag: str, data) -> None:
+    def _store_data(self, dataset_id: str, name_tag: str, data, row_group_size=None) -> None:
         """
-        Stores data as a cached file. Pandas/Polars DataFrames are stored as 
+        Stores data as a cached file. Pandas/Polars DataFrames are stored as
         parquet files, while all other data structures are stored as
         compressed pickle.
         Args:
-            dataset_id (str): The name of the dataset the data is 
+            dataset_id (str): The name of the dataset the data is
                 attached to.
             name_tag (str): The name of the associated data structure.
             data: Any pickleable data structure.
+            row_group_size (int, optional): Row group size for parquet files.
+                If None, the library default is used.
 
         Returns:
             file_path (Path): The file path of the stored file.
         """
-        
+
         path = Path(self.cache_path, 'files', dataset_id)
         path.mkdir(parents=True, exist_ok=True)
-        
+
         # Polars DataFrames and LazyFrames are stored as parquet
         if isinstance(data, (pl.DataFrame, pl.LazyFrame)):
             path = Path(path, f"{name_tag}.pq")
-            # Convert LazyFrame to DataFrame for writing
             if isinstance(data, pl.LazyFrame):
-                data = data.sink_parquet(path)
+                # Keep the streaming sink when no bounded row groups are requested
+                # (default callers). Only materialize when row_group_size is set,
+                # since sink_parquet on this polars version rejects the kwarg.
+                if row_group_size is None:
+                    data.sink_parquet(path)
+                else:
+                    data.collect().write_parquet(path, row_group_size=row_group_size)
             else:
-                data.write_parquet(path)
+                data.write_parquet(path, row_group_size=row_group_size)
             return path
         # Pandas DataFrames are stored as parquet
         elif isinstance(data, pd.DataFrame):
             path = Path(path, f"{name_tag}.pq")
             with open(path, 'wb') as f:
-                data.to_parquet(f)
+                data.to_parquet(f, row_group_size=row_group_size)
             return path
         # Other data structures are stored as compressed pickle
         else:
@@ -329,19 +336,21 @@ class FileManager:
                 pkl.dump(data, f)
             return path
 
-    def store_data(self, dataset_id: str, name_tag: str, data) -> None:
+    def store_data(self, dataset_id: str, name_tag: str, data, row_group_size=None) -> None:
         """
         Stores a given data structure.
 
         Args:
-            dataset_id (str): The name of the dataset the data is 
+            dataset_id (str): The name of the dataset the data is
                 attached to.
             name_tag (str): The name of the associated data structure.
             data: Any pickleable data structure.
+            row_group_size (int, optional): Row group size for parquet files.
+                If None, the library default is used.
         """
 
         # Store datastructure as file
-        data_path = self._store_data(dataset_id, name_tag, data)
+        data_path = self._store_data(dataset_id, name_tag, data, row_group_size=row_group_size)
 
         # Store reference in index
         data_path = data_path.resolve()


### PR DESCRIPTION
Switch the FLASHTnT viewer's per-scan caches from eager whole-file loads to per-scan pyarrow predicate pushdown. The caches are written with bounded parquet row groups (sorted by their lookup key) so a per-scan filter skips non-matching row groups instead of re-reading the whole file.

- FileManager.store_data: optional row_group_size; keeps the streaming sink for default callers, materializes only when a bound is requested
- deconv.py: bound the five per-scan spectra caches (row groups of 64)
- tnt.py: stable Scan-sort tag_dfs + bounded row groups
- initialize.py: return a pyarrow dataset handle for flashtnt
- update.py: filter_data pushes the selected scan down (spectra by index, tags by Scan) and stamps ProteinIndex

FLASHDeconv viewer keeps eager loading. Pre-existing single-row-group caches must be reprocessed to gain the speedup. Golden postprocessing smoke unchanged (27 passed / 1 skipped).