### PR TITLE
Bump FLASHApp version to 1.0.0

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -14,7 +14,7 @@ env:
   OPENMS_VERSION: 3.5.0
   PYTHON_VERSION: 3.11.0
   # Name of the installer
-  APP_NAME: FLASHApp-0.9.15
+  APP_NAME: FLASHApp-1.0.0
   APP_UpgradeCode: "69ae44ad-d554-4e3c-8715-7c4daf60f8bb"
 
 jobs:

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
     "app-name": "FLASHApp",
     "github-user": "OpenMS",
-    "version": "0.9.15",
+    "version": "1.0.0",
     "repository-name": "FLASHApp",
     "analytics": {
         "google-analytics": {


### PR DESCRIPTION
## Summary
Release FLASHApp version 1.0.0, updating version references across build and configuration files.

## Changes
- Updated `APP_NAME` in GitHub Actions Windows build workflow from `FLASHApp-0.9.15` to `FLASHApp-1.0.0`
- Updated `version` in `settings.json` from `0.9.15` to `1.0.0`

## Details
This is a version bump for the FLASHApp release, updating the application version identifier used in the Windows executable installer build process and the application configuration file. The version is now aligned across both the CI/CD pipeline and the application settings.

https://claude.ai/code/session_01HRTebyn6rk8CzEmzx7H5C2