### PR TITLE
Remove thread configuration from workflows

### DIFF
--- a/src/Workflow.py
+++ b/src/Workflow.py
@@ -1,6 +1,5 @@
 import json
 import time
-import multiprocessing
 
 import streamlit as st
 
@@ -12,8 +11,6 @@ from os.path import join, splitext, basename, exists, dirname
 from src.parse.tnt import parseTnT
 from src.parse.deconv import parseDeconv
 from src.workflow.WorkflowManager import WorkflowManager
-
-DEFAULT_THREADS = 8
 
 EXAMPLE_DATA = [
     'example-data/deconv/example_lc_ms.mzML',
@@ -44,13 +41,6 @@ class TagWorkflow(WorkflowManager):
         # Input File Selection
         self.ui.select_input_file("mzML-files", multiple=True)
         self.ui.select_input_file("fasta-file", multiple=False)
-
-        # Number of threads cannot be selected in online mode
-        if st.session_state.location != "online":
-            self.ui.input_widget(
-                'threads', name='threads', default=multiprocessing.cpu_count(),
-                help='The number of threads that should be used to run the tools.'
-            )
 
         # Decoy database size toggle
         self.ui.input_widget(
@@ -102,12 +92,6 @@ class TagWorkflow(WorkflowManager):
         # Make sure output directory exists
         base_path = dirname(self.workflow_dir)
         
-        # Define output directory
-        if 'threads' in self.executor.parameter_manager.get_parameters_from_json():
-            threads = self.executor.parameter_manager.get_parameters_from_json()['threads']
-        else:
-            threads = DEFAULT_THREADS
-
         errors = []
         # Process files in sequence
         for in_mzml in in_mzmls:
@@ -190,9 +174,6 @@ class TagWorkflow(WorkflowManager):
                         'out_feature1' : [out_feature1],
                         'out_feature2' : [out_feature2],
                     },
-                    custom_params = {
-                        'threads' : threads
-                    }
                 )
 
                 self.logger.log(f"-> Running FLASHTnT...")
@@ -207,9 +188,6 @@ class TagWorkflow(WorkflowManager):
                         'out_pro' :  [out_protein],
                         'out_prsm' : [out_prsm]
                     },
-                    custom_params = {
-                        'threads' : threads
-                    }
                 )
 
                 self.logger.log(f"-> Processing Results...")
@@ -298,14 +276,6 @@ class DeconvWorkflow(WorkflowManager):
         # Input File Selection
         self.ui.select_input_file("mzML-files", multiple=True)
 
-        # Number of threads cannot be selected in online mode
-        if st.session_state.location != "online":
-            self.ui.input_widget(
-                'threads', name='threads', default=multiprocessing.cpu_count(),
-                help='The number of threads that should be used to run the tools.'
-            )
-
-
         # FLASHDeconv Configuration
         self.ui.input_TOPP(
             'FLASHDeconv', exclude_parameters = ['ida_log'], display_subsections=True,
@@ -322,12 +292,6 @@ class DeconvWorkflow(WorkflowManager):
         
         # Define output directory
         base_path = dirname(self.workflow_dir)
-
-        # Set number of threads
-        if 'threads' in self.executor.parameter_manager.get_parameters_from_json():
-            threads = self.executor.parameter_manager.get_parameters_from_json()['threads']
-        else:
-            threads = DEFAULT_THREADS
 
         errors = []
         # Process files in sequence
@@ -378,9 +342,6 @@ class DeconvWorkflow(WorkflowManager):
                         'out_feature1' : [out_feature1],
                         'out_feature2' : [out_feature2],
                     },
-                    custom_params = {
-                        'threads' : threads
-                    }
                 )
 
                 self.logger.log(f"-> Processing Results...")


### PR DESCRIPTION
## Summary

Removes thread count configuration from the TNT and Deconv workflows. The `threads` parameter is no longer exposed in the UI, and thread configuration is no longer passed to TOPP tool execution.

## Changes

- **Removed UI input**: Deleted the conditional thread count input widget from both `TNTWorkflow.configure()` and `DeconvWorkflow.configure()` that was previously only shown in non-online deployments
- **Removed parameter handling**: Eliminated logic that retrieved the `threads` parameter from the parameter manager with a fallback to `DEFAULT_THREADS`
- **Removed custom parameters**: Deleted `custom_params={'threads': threads}` arguments from `run_topp()` calls for both FLASHTnT and FLASHDeconv tool executions
- **Removed constants**: Deleted the `DEFAULT_THREADS = 8` constant and `multiprocessing` import that are no longer needed

## Implementation Details

The changes affect two workflow classes:
- `TNTWorkflow`: Removed thread UI input and custom_params from FLASHTnT and ProteinQuantifier tool runs
- `DeconvWorkflow`: Removed thread UI input and custom_params from FLASHDeconv tool run

Thread management is now handled entirely by the TOPP tools themselves or the system configuration, rather than being user-configurable through the Streamlit interface.

https://claude.ai/code/session_01FnjMr4r4DJgKHPLSGkrM1C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed user-configurable thread settings from TagWorkflow and DeconvWorkflow. Thread management is now handled automatically for all pipeline executions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/FLASHApp/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->