### PR TITLE
Optimize Docker build cache by reordering JS component build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,24 +8,8 @@
 # prune unused images/etc. to free disc space (e.g. might be needed on gitpod). Use with care.: docker system prune --all --force
 
 
-# Build JS-component
-FROM node:21 AS js-build
-
-# JS Component
-ARG VUE_REPO=https://github.com/t0mdavid-m/openms-streamlit-vue-component.git
-ARG VUE_BRANCH=FVdeploy
-
-ADD https://api.github.com/repos/t0mdavid-m/openms-streamlit-vue-component/git/refs/heads/$VUE_BRANCH version.json
-
-RUN git clone -b ${VUE_BRANCH} --single-branch ${VUE_REPO}
-WORKDIR /openms-streamlit-vue-component
-RUN npm install
-RUN npm run build
-
 FROM ubuntu:24.04 AS setup-build-system
 WORKDIR /
-
-COPY --from=js-build openms-streamlit-vue-component/dist /app/js-component/dist
 
 ARG OPENMS_REPO=https://github.com/t0mdavid-m/OpenMS.git
 ARG OPENMS_BRANCH=FVdeploy
@@ -144,6 +128,22 @@ ENV OPENMS_DATA_PATH="/openms/share/"
 # Remove build directory.
 RUN rm -rf openms-build
 
+# Build JS-component (quick). Placed after the slow OpenMS build so that changes
+# to the Vue component do not invalidate the OpenMS compile cache; its output is
+# copied into the final image in the run-app stage below.
+FROM node:21 AS js-build
+
+# JS Component
+ARG VUE_REPO=https://github.com/t0mdavid-m/openms-streamlit-vue-component.git
+ARG VUE_BRANCH=FVdeploy
+
+ADD https://api.github.com/repos/t0mdavid-m/openms-streamlit-vue-component/git/refs/heads/$VUE_BRANCH version.json
+
+RUN git clone -b ${VUE_BRANCH} --single-branch ${VUE_REPO}
+WORKDIR /openms-streamlit-vue-component
+RUN npm install
+RUN npm run build
+
 # Prepare and run streamlit app.
 FROM compile-openms AS run-app
 
@@ -186,6 +186,9 @@ COPY app.py /app/app.py
 COPY settings.json /app/settings.json
 COPY default-parameters.json /app/default-parameters.json
 COPY presets.json /app/presets.json
+
+# Copy the pre-built Vue/JS component (built in the js-build stage above).
+COPY --from=js-build openms-streamlit-vue-component/dist /app/js-component/dist
 
 # add cron job to the crontab
 RUN echo "0 3 * * * /root/miniforge3/envs/streamlit-env/bin/python /app/clean-up-workspaces.py >> /app/clean-up-workspaces.log 2>&1" | crontab -

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -8,24 +8,8 @@
 # prune unused images/etc. to free disc space (e.g. might be needed on gitpod). Use with care.: docker system prune --all --force
 
 
-# Build JS-component
-FROM node:21 AS js-build
-
-# JS Component
-ARG VUE_REPO=https://github.com/t0mdavid-m/openms-streamlit-vue-component.git
-ARG VUE_BRANCH=FVdeploy
-
-ADD https://api.github.com/repos/t0mdavid-m/openms-streamlit-vue-component/git/refs/heads/$VUE_BRANCH version.json
-
-RUN git clone -b ${VUE_BRANCH} --single-branch ${VUE_REPO}
-WORKDIR /openms-streamlit-vue-component
-RUN npm install
-RUN npm run build
-
 FROM ubuntu:24.04 AS setup-build-system
 WORKDIR /
-
-COPY --from=js-build openms-streamlit-vue-component/dist /app/js-component/dist
 
 ARG OPENMS_REPO=https://github.com/t0mdavid-m/OpenMS.git
 ARG OPENMS_BRANCH=FVdeploy
@@ -139,6 +123,22 @@ ENV OPENMS_DATA_PATH="/openms/share/"
 # Remove build directory.
 RUN rm -rf openms-build
 
+# Build JS-component (quick). Placed after the slow OpenMS build so that changes
+# to the Vue component do not invalidate the OpenMS compile cache; its output is
+# copied into the final image in the run-app stage below.
+FROM node:21 AS js-build
+
+# JS Component
+ARG VUE_REPO=https://github.com/t0mdavid-m/openms-streamlit-vue-component.git
+ARG VUE_BRANCH=FVdeploy
+
+ADD https://api.github.com/repos/t0mdavid-m/openms-streamlit-vue-component/git/refs/heads/$VUE_BRANCH version.json
+
+RUN git clone -b ${VUE_BRANCH} --single-branch ${VUE_REPO}
+WORKDIR /openms-streamlit-vue-component
+RUN npm install
+RUN npm run build
+
 # Prepare and run streamlit app.
 FROM compile-openms AS run-app
 
@@ -167,6 +167,9 @@ COPY app.py /app/app.py
 COPY settings.json /app/settings.json
 COPY default-parameters.json /app/default-parameters.json
 COPY presets.json /app/presets.json
+
+# Copy the pre-built Vue/JS component (built in the js-build stage above).
+COPY --from=js-build openms-streamlit-vue-component/dist /app/js-component/dist
 
 # add cron job to the crontab
 RUN echo "0 3 * * * /root/miniforge3/envs/streamlit-env/bin/python /app/clean-up-workspaces.py >> /app/clean-up-workspaces.log 2>&1" | crontab -


### PR DESCRIPTION
## Summary

Reorganized the Docker multi-stage build to improve cache efficiency by moving the JS component build after the OpenMS compilation step. This prevents Vue component changes from invalidating the expensive OpenMS build cache.

## Changes

- **Moved `js-build` stage** from the beginning (before `setup-build-system`) to after the `compile-openms` stage
- **Removed early COPY** of JS component dist files from `setup-build-system` stage
- **Added late COPY** of JS component dist files in the `run-app` stage (after OpenMS compilation completes)
- **Applied to both Dockerfiles**: `Dockerfile` and `Dockerfile.arm` (ARM64 variant)
- **Added explanatory comment** documenting the rationale: "Placed after the slow OpenMS build so that changes to the Vue component do not invalidate the OpenMS compile cache"

## Implementation Details

The build order is now:
1. `setup-build-system` — prepares Ubuntu environment
2. `compile-openms` — slow C++ compilation (~30+ minutes)
3. `js-build` — quick Node.js build (~1-2 minutes)
4. `run-app` — final image with both OpenMS and JS component

This ensures that iterating on the Vue/JS component (in `openms-streamlit-vue-component`) doesn't trigger a full OpenMS recompile, significantly reducing development iteration time while maintaining the same final image output.

https://claude.ai/code/session_01LKVYqChsNCR4X2bQiZA9Dw