### PR TITLE
fix(workflow): report success for clean local runs

### DIFF
--- a/src/Workflow.py
+++ b/src/Workflow.py
@@ -86,7 +86,7 @@ class TagWorkflow(WorkflowManager):
             )
 
 
-    def execution(self) -> None:
+    def execution(self) -> bool:
         # Get input files
         try:      
             in_mzmls = self.file_manager.get_files(self.params["mzML-files"])
@@ -279,6 +279,8 @@ class TagWorkflow(WorkflowManager):
         if errors:
             raise ExceptionGroup("Errors during processing", errors)
 
+        return True
+
 
 class DeconvWorkflow(WorkflowManager):
     share_cache = True
@@ -312,7 +314,7 @@ class DeconvWorkflow(WorkflowManager):
         )
 
 
-    def execution(self) -> None:
+    def execution(self) -> bool:
         # Get input files
         try:
             in_mzmls = self.file_manager.get_files(self.params["mzML-files"])
@@ -430,6 +432,8 @@ class DeconvWorkflow(WorkflowManager):
                 errors.append(e)
         if errors:
             raise ExceptionGroup("Errors during processing", errors)
+
+        return True
 
 
 class QuantWorkflow(WorkflowManager):


### PR DESCRIPTION
TagWorkflow.execution and DeconvWorkflow.execution returned None on the success path (they only raise on failure). workflow_process logs the "WORKFLOW FINISHED" marker only `if success:` where `success = self.execution()`, so a clean local run never wrote the marker and classify_log_outcome fell back to "error" -- every successful local workflow showed "Errors occurred, check log file."

Return True from both overrides so the marker is written. Online/queue mode was unaffected: tasks.py logs the marker unconditionally and the UI reads the RQ job result, not the log.