### PR TITLE
bump version to 1.0.1

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -14,7 +14,7 @@ env:
   OPENMS_VERSION: 3.5.0
   PYTHON_VERSION: 3.11.0
   # Name of the installer
-  APP_NAME: FLASHApp-1.0.0
+  APP_NAME: FLASHApp-1.0.1
   APP_UpgradeCode: "69ae44ad-d554-4e3c-8715-7c4daf60f8bb"
 
 jobs:

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
     "app-name": "FLASHApp",
     "github-user": "OpenMS",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "repository-name": "FLASHApp",
     "legal_links": {
         "impressum": "https://openms.de/impressum",


### PR DESCRIPTION
Bump the FLASHApp version `1.0.0` → `1.0.1`.

- `settings.json` → `"version": "1.0.1"`
- `.github/workflows/build-windows-executable-app.yaml` → `APP_NAME: FLASHApp-1.0.1`

Same two locations the previous bump (#83) touched. Follows #95 (upstream streamlit-template merge), which landed before this bump was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)